### PR TITLE
Implemented dynamic baker apy

### DIFF
--- a/Mvkt.Api.Tests/Api/TestRewardsQueries.cs
+++ b/Mvkt.Api.Tests/Api/TestRewardsQueries.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Dynamic.Json;
 using Dynamic.Json.Extensions;
@@ -39,6 +39,25 @@ namespace Mvkt.Api.Tests.Api
             var res = await Client.GetJsonAsync($"/v1/rewards/bakers/{Settings.Baker}/stats");
 
             Assert.True(res is DJsonObject);
+            
+            Assert.True((double)res.luck >= 0);
+            Assert.True((double)res.performance >= 0 && (double)res.performance <= 100);
+            Assert.True((double)res.reliability >= 0 && (double)res.reliability <= 100);
+            Assert.True((long)res.totalExpectedRewards >= 0);
+            Assert.True((long)res.totalActualRewards >= 0);
+            
+            if (res.apy != null)
+            {
+                Assert.True(res.apy is DJsonObject);
+                
+                Assert.True((double)res.apy.ownStakeApy >= 0);
+                Assert.True((double)res.apy.externalStakeApy >= 0);
+                Assert.True((double)res.apy.delegationApy >= 0);
+                
+                Assert.True((double)res.apy.ownStakeApy < 1000);
+                Assert.True((double)res.apy.externalStakeApy < 1000);
+                Assert.True((double)res.apy.delegationApy < 1000);
+            }
         }
 
         [Fact]

--- a/Mvkt.Api/Repositories/StakingRepository.cs
+++ b/Mvkt.Api/Repositories/StakingRepository.cs
@@ -1,4 +1,3 @@
-﻿using System.Data;
 using Dapper;
 using Npgsql;
 using Mvkt.Api.Models;
@@ -487,68 +486,89 @@ namespace Mvkt.Api.Repositories
                 return null;
 
             var protocol = Protocols.Current;
+            var currentCycle = State.Current.Cycle;
+            
+            var secondsPerCycle = protocol.TimeBetweenBlocks * protocol.BlocksPerCycle;
+            var cyclesPerYear = 365.0 * 24 * 60 * 60 / secondsPerCycle;
+            
+            // Get last N completed cycles of rewards data for this baker (use 12 cycles for better averaging)
+            const int cyclesToAnalyze = 12;
+            
             await using var db = await DataSource.OpenConnectionAsync();
-
-            var total = await db.QueryFirstOrDefaultAsync($"""
-                SELECT  COALESCE(SUM("OwnStakedBalance"), 0)::bigint AS "OwnStaked",
-                        COALESCE(SUM("ExternalStakedBalance"), 0)::bigint AS "ExternalStaked",
-                        COALESCE(SUM("Balance" - "OwnStakedBalance"), 0)::bigint AS "OwnDelegated",
-                        COALESCE(SUM("DelegatedBalance"), 0)::bigint AS "ExternalDelegated"
-                FROM "Accounts"
-                WHERE "Type" = 1
-                AND "Staked" = true
-            """);
-
-            var futureCycle = await db.QueryFirstAsync<Data.Models.Cycle>("""
-                SELECT *
-                FROM "Cycles"
-                ORDER BY "Index" DESC
-                LIMIT 1
-                """);
-
-            var lbSubsidyPerBlock = 5_000_000 * protocol.TimeBetweenBlocks / 60;
-            var maxRewardsPerBlock = futureCycle.BlockReward
-                + futureCycle.BlockBonusPerSlot * (protocol.EndorsersPerBlock - protocol.ConsensusThreshold)
-                + futureCycle.EndorsementRewardPerSlot * protocol.EndorsersPerBlock;
-
-            var blocksPerYear = 365 * 24 * 60 * 60 / protocol.TimeBetweenBlocks;
-            var totalRewardsPerYear = maxRewardsPerBlock * blocksPerYear;
-            var totalRewardsPerMonth = totalRewardsPerYear / 12;
-
-            var totalStaked = (long)total.OwnStaked + (long)total.ExternalStaked;
-            var totalDelegated = (long)total.OwnDelegated + (long)total.ExternalDelegated;
-            var totalEffectiveStake = 2 * totalStaked + totalDelegated / protocol.StakePowerMultiplier;
-
-            if (totalEffectiveStake == 0)
+            
+            var cycles = (await db.QueryAsync<Data.Models.BakerCycle>("""
+                SELECT 
+                    "OwnStakedBalance",
+                    "ExternalStakedBalance",
+                    "OwnDelegatedBalance",
+                    "ExternalDelegatedBalance",
+                    "BlockRewardsStakedOwn",
+                    "BlockRewardsStakedEdge",
+                    "BlockRewardsStakedShared",
+                    "BlockRewardsDelegated",
+                    "EndorsementRewardsStakedOwn",
+                    "EndorsementRewardsStakedEdge",
+                    "EndorsementRewardsStakedShared",
+                    "EndorsementRewardsDelegated",
+                    "VdfRevelationRewardsStakedOwn",
+                    "VdfRevelationRewardsStakedEdge",
+                    "VdfRevelationRewardsStakedShared",
+                    "VdfRevelationRewardsDelegated",
+                    "NonceRevelationRewardsStakedOwn",
+                    "NonceRevelationRewardsStakedEdge",
+                    "NonceRevelationRewardsStakedShared",
+                    "NonceRevelationRewardsDelegated"
+                FROM "BakerCycles"
+                WHERE "BakerId" = @bakerId
+                AND "Cycle" < @currentCycle
+                ORDER BY "Cycle" DESC
+                LIMIT @limit
+                """, new { bakerId = delegat.Id, currentCycle, limit = cyclesToAnalyze })).ToList();
+            
+            if (cycles.Count == 0)
                 return null;
 
-            var baseMonthlyRate = (double)totalRewardsPerMonth / totalEffectiveStake;
-
-            var ownStakeMonthlyRewards = baseMonthlyRate * 2 * delegat.OwnStakedBalance;
+            var totalOwnStakeRewards = cycles.Sum(r =>
+                r.BlockRewardsStakedOwn + r.BlockRewardsStakedEdge +
+                r.EndorsementRewardsStakedOwn + r.EndorsementRewardsStakedEdge +
+                r.VdfRevelationRewardsStakedOwn + r.VdfRevelationRewardsStakedEdge +
+                r.NonceRevelationRewardsStakedOwn + r.NonceRevelationRewardsStakedEdge);
             
-            var externalStakeMonthlyRewards = baseMonthlyRate * delegat.ExternalStakedBalance;
+            var totalExternalStakeRewards = cycles.Sum(r =>
+                r.BlockRewardsStakedShared +
+                r.EndorsementRewardsStakedShared +
+                r.VdfRevelationRewardsStakedShared +
+                r.NonceRevelationRewardsStakedShared);
             
-            var delegatedMonthlyRewards = baseMonthlyRate * delegat.DelegatedBalance / protocol.StakePowerMultiplier;
-
-            var ownStakeMonthlyYield = delegat.OwnStakedBalance > 0
-                ? ownStakeMonthlyRewards / delegat.OwnStakedBalance
+            var totalDelegationRewards = cycles.Sum(r =>
+                r.BlockRewardsDelegated +
+                r.EndorsementRewardsDelegated +
+                r.VdfRevelationRewardsDelegated +
+                r.NonceRevelationRewardsDelegated);
+            
+            var avgOwnStakedBalance = cycles.Average(r => (double)r.OwnStakedBalance);
+            var avgExternalStakedBalance = cycles.Average(r => (double)r.ExternalStakedBalance);
+            var avgDelegatedBalance = cycles.Average(r => (double)(r.OwnDelegatedBalance + r.ExternalDelegatedBalance));
+            
+            var ownStakeCycleYield = avgOwnStakedBalance > 0
+                ? totalOwnStakeRewards / cycles.Count / avgOwnStakedBalance
                 : 0.0;
-            var ownStakeApy = ownStakeMonthlyYield > 0
-                ? (Math.Pow(1 + ownStakeMonthlyYield, 12) - 1) * 100
+            var ownStakeApy = ownStakeCycleYield > 0
+                ? (Math.Pow(1 + ownStakeCycleYield, cyclesPerYear) - 1) * 100
                 : 0.0;
-
-            var externalStakeMonthlyYield = delegat.ExternalStakedBalance > 0
-                ? externalStakeMonthlyRewards / delegat.ExternalStakedBalance
+            
+            var externalStakeCycleYield = avgExternalStakedBalance > 0
+                ? totalExternalStakeRewards / cycles.Count / avgExternalStakedBalance
                 : 0.0;
-            var externalStakeApy = externalStakeMonthlyYield > 0
-                ? (Math.Pow(1 + externalStakeMonthlyYield, 12) - 1) * 100
+            var externalStakeApy = externalStakeCycleYield > 0
+                ? (Math.Pow(1 + externalStakeCycleYield, cyclesPerYear) - 1) * 100
                 : 0.0;
-
-            var delegationMonthlyYield = delegat.DelegatedBalance > 0
-                ? delegatedMonthlyRewards / delegat.DelegatedBalance
+            
+            var delegationCycleYield = avgDelegatedBalance > 0
+                ? totalDelegationRewards / cycles.Count / avgDelegatedBalance
                 : 0.0;
-            var delegationApy = delegationMonthlyYield > 0
-                ? (Math.Pow(1 + delegationMonthlyYield, 12) - 1) * 100
+            var delegationApy = delegationCycleYield > 0
+                ? (Math.Pow(1 + delegationCycleYield, cyclesPerYear) - 1) * 100
                 : 0.0;
 
             return new BakerApy

--- a/Mvkt.Api/Repositories/StakingRepository.cs
+++ b/Mvkt.Api/Repositories/StakingRepository.cs
@@ -491,7 +491,6 @@ namespace Mvkt.Api.Repositories
             var secondsPerCycle = protocol.TimeBetweenBlocks * protocol.BlocksPerCycle;
             var cyclesPerYear = 365.0 * 24 * 60 * 60 / secondsPerCycle;
             
-            // Get last N completed cycles of rewards data for this baker (use 12 cycles for better averaging)
             const int cyclesToAnalyze = 12;
             
             await using var db = await DataSource.OpenConnectionAsync();


### PR DESCRIPTION
Fixed APY calculation to be personalized per baker based on their actual historical performance.

### Issue
All bakers were showing identical APY values regardless of their actual performance:
- `ownStakeApy`: 17.64% (same for everyone)
- `delegationApy`: 4.17% (same for everyone)

The original implementation in `StakingRepository.GetBakerApy()` calculated APY using a theoretical formula based on global network parameters:

```csharp
var baseMonthlyRate = totalRewardsPerMonth / totalEffectiveStake;
var ownStakeMonthlyRewards = baseMonthlyRate * 2 * delegat.OwnStakedBalance;
var ownStakeMonthlyYield = ownStakeMonthlyRewards / delegat.OwnStakedBalance; 
```

### Solution
Changed APY calculation to use actual historical rewards data from the last 12 completed cycles for each specific baker.
